### PR TITLE
Hotfix ben max collision2nd order population init update scheme jx jy jz

### DIFF
--- a/src/equilibration.f90
+++ b/src/equilibration.f90
@@ -142,6 +142,7 @@ SUBROUTINE equilibration
     !
     do t=1,HUGE(t)
 
+
         !
         ! Print sdtout timestep, etc
         !
@@ -266,32 +267,39 @@ SUBROUTINE equilibration
         jy_old = jy
         jz_old = jz
 
+        !IF( MODULO(t, print_frequency) == 0) PRINT*,  t, "before", jz(1,1,1)
+
         ! update momentum densities after the propagation
         ! this is completely local in space and my be parallelized very well
-        !$OMP PARALLEL DO DEFAULT(NONE)&
-        !$OMP PRIVATE(l)&
-        !$OMP SHARED(lmin,lmax,n,cx,cy,cz)&
-        !$OMP REDUCTION(+:jx)&
-        !$OMP REDUCTION(+:jy)&
-        !$OMP REDUCTION(+:jz)
-        do l=lmin,lmax
-            jx = jx +n(:,:,:,l)*cx(l)
-            jy = jy +n(:,:,:,l)*cy(l)
-            jz = jz +n(:,:,:,l)*cz(l)
-        end do
-        !$OMP END PARALLEL DO
-        jx=jx/2
-        jy=jy/2
-        jz=jz/2
-        ! ! BEN+MAX: 12/07/2016 change the way we integrate n_l*c_l
-        ! jx=0
-        ! jy=0
-        ! jz=0
+        ! !$OMP PARALLEL DO DEFAULT(NONE)&
+        ! !$OMP PRIVATE(l)&
+        ! !$OMP SHARED(lmin,lmax,n,cx,cy,cz)&
+        ! !$OMP REDUCTION(+:jx)&
+        ! !$OMP REDUCTION(+:jy)&
+        ! !$OMP REDUCTION(+:jz)
         ! do l=lmin,lmax
         !     jx = jx +n(:,:,:,l)*cx(l)
         !     jy = jy +n(:,:,:,l)*cy(l)
         !     jz = jz +n(:,:,:,l)*cz(l)
         ! end do
+        ! !$OMP END PARALLEL DO
+        ! jx=jx/2
+        ! jy=jy/2
+        ! jz=jz/2
+        ! BEN+MAX: 12/07/2016 change the way we integrate n_l*c_l
+        !jx=0
+        !jy=0
+        !jz=0
+        jx=f_ext_x/2._dp
+        jy=f_ext_y/2._dp
+        jz=f_ext_z/2._dp
+        do l=lmin,lmax
+            jx = jx +n(:,:,:,l)*cx(l)
+            jy = jy +n(:,:,:,l)*cy(l)
+            jz = jz +n(:,:,:,l)*cz(l)
+        end do
+        
+        !IF( MODULO(t, print_frequency) == 0) PRINT*,  t, "after ", jz(1,1,1)
 
         !
         ! Dominika

--- a/src/init_simu.f90
+++ b/src/init_simu.f90
@@ -1,7 +1,7 @@
 SUBROUTINE init_simu
 
     USE precision_kinds
-    USE mod_lbmodel, ONLY: init_everything_related_to_lb_model => initialize
+    USE mod_lbmodel, ONLY: init_everything_related_to_lb_model => initialize, lbm
     USE system, ONLY: node, n, solid
     USE io, ONLY: print_header, print_input_in_output_folder, inquireNecessaryFilesExistence
     USE myallocations
@@ -10,6 +10,7 @@ SUBROUTINE init_simu
     IMPLICIT NONE
 
     REAL(dp) :: svden
+    integer :: l
 
     CALL print_header
     CALL inquireNecessaryFilesExistence  ! check that input, output folder and file ./lb.in exist
@@ -33,6 +34,10 @@ SUBROUTINE init_simu
     ELSEWHERE
         node%solventdensity = 0
     END WHERE
+    do l= lbm%lmin, lbm%lmax
+      n(:,:,:,l) = node%solventdensity * lbm%vel(l)%a0
+    end do
+
 
     CALL charges_init    ! init charge distribution
 


### PR DESCRIPTION

This is a bug fix :    
- The populations, `n(x,y,z,l)` where init to 0 everywhere (in init_simu.f90). They are not initilized to density(x,y,z)*a0(l).   
- the update scheme for the flux, jx, jy, jz has been changed to its natural value : 
- The collision operator has been updated  

The beginning of the VACF is not as smooth as expected. To be understood later.